### PR TITLE
Fix the relocation overflow problem due to the size of the chrome executable file

### DIFF
--- a/recipes-browser/chromium/chromium_60.0.3112.101.bb
+++ b/recipes-browser/chromium/chromium_60.0.3112.101.bb
@@ -124,6 +124,8 @@ GN_ARGS += "is_debug=false is_official_build=true"
 #    not cause any issues if DEBUG_BUILD is set, as -g1 will be passed later.
 DEBUG_FLAGS_remove_i586 = "-g"
 DEBUG_FLAGS_append_i586 = "-g1"
+DEBUG_FLAGS_remove_x86-64 = "-g"
+DEBUG_FLAGS_append_x86-64 = "-g1"
 DEBUG_FLAGS_remove_armv6 = "-g"
 DEBUG_FLAGS_append_armv6 = "-g1"
 DEBUG_FLAGS_remove_armv7a = "-g"


### PR DESCRIPTION
Here is a part of the build logs:
| obj/third_party/WebKit/Source/core/libcore_generated.a(ScriptModule.o)(.debug_loc+0x5b30): error: relocation overflow: reference to local symbol 31 in obj/third_party/WebKit/Source/core/libcore_generated.a(ScriptModule.o)
| obj/third_party/WebKit/Source/core/libcore_generated.a(ScriptModule.o)(.debug_aranges+0x6): error: relocation overflow: reference to local symbol 31 in obj/third_party/WebKit/Source/core/libcore_generated.a(ScriptModule.o)
