### PR TITLE
Add support for i686.

### DIFF
--- a/recipes-browser/chromium/chromium_61.0.3163.100.bb
+++ b/recipes-browser/chromium/chromium_61.0.3163.100.bb
@@ -133,6 +133,8 @@ GN_ARGS += "use_custom_libcxx=false"
 #    not cause any issues if DEBUG_BUILD is set, as -g1 will be passed later.
 DEBUG_FLAGS_remove_i586 = "-g"
 DEBUG_FLAGS_append_i586 = "-g1"
+DEBUG_FLAGS_remove_i686 = "-g"
+DEBUG_FLAGS_append_i686 = "-g1"
 DEBUG_FLAGS_remove_armv6 = "-g"
 DEBUG_FLAGS_append_armv6 = "-g1"
 DEBUG_FLAGS_remove_armv7a = "-g"

--- a/recipes-browser/chromium/gn-utils.inc
+++ b/recipes-browser/chromium/gn-utils.inc
@@ -5,6 +5,7 @@ def gn_arch_name(yocto_arch):
         'aarch64': 'arm64',
         'arm': 'arm',
         'i586': 'x86',
+        'i686': 'x86',
         'x86_64': 'x64',
     }
     try:


### PR DESCRIPTION
Core2-32 targets use i686 instead of i586.  This could not be resolved by GN

Signed-off-by: Michael Davis <michael.davis@essvote.com>